### PR TITLE
Add TEAMWORK.md with group info and markdown features

### DIFF
--- a/TEAMWORK.md
+++ b/TEAMWORK.md
@@ -3,8 +3,9 @@
 ## Group Members: 
 - Harvey Palalay
 - Juntai George Cao
+- Yvette Ni
 - Xiaoxi Gao
-- Audrey Siu
+- Audrey Siu (not responding on slack as of 14 Sep 2025 @ 10:33 PM)
 
 ### Project Link: [GitHub Repository] (https://github.com/stat545ubc-2025/collaborative-project-group-18)
 


### PR DESCRIPTION
- Created TEAMWORK.md file to demonstrate 5 Markdown features containing:
  - Group members (added Yvette Ni as a group member and included a comment on Audrey Siu)
  - GitHub repository link
  - Exercises & tasks
  - Project deliverable due date
 
- Hi @juntaic7 please review, comment and merge. 
- Hi @Xiaoxi-Gao7 @yvetteni for your information only. 