### PR TITLE
Fix error in exercise 6 in troubleshooting-2.Rmd: (Q6) Manually create tibble with 4 columns (GRADED)

### DIFF
--- a/troubleshooting-2.Rmd
+++ b/troubleshooting-2.Rmd
@@ -182,17 +182,16 @@ Manually create a tibble with 4 columns:
 -   `birth_location` should contain three locations (Liverpool, Seattle, and New York).
 
 ```{r}
-### ERROR HERE ###
 fakeStarWars <- tribble(
-  ~name,            ~birth_weight,  ~birth_year, ~birth_location
-  "Luke Skywalker",  1.35      ,   1998        ,  Liverpool, England,
-  "C-3PO"         ,  1.80      ,   1999        ,  Liverpool, England,
-  "R2-D2"         ,  2.25      ,   2000        ,  Seattle, WA,
-  "Darth Vader"   ,  2.70      ,   2001        ,  Liverpool, England,
-  "Leia Organa"   ,  3.15      ,   2002        ,  New York, NY,
-  "Owen Lars"     ,  3.60      ,   2003        ,  Seattle, WA,
-  "Beru Whitesun Iars", 4.05   ,   2004        ,  Liverpool, England,
-  "R5-D4"         ,  4.50      ,   2005        ,  New York, NY,
+  ~name,            ~birth_weight,  ~birth_year, ~birth_location,
+  "Luke Skywalker", 1.35,           1998,        "Liverpool",
+  "C-3PO",          1.80,           1999,        "Liverpool",
+  "R2-D2",          2.25,           2000,        "Seattle",
+  "Darth Vader",    2.70,           2001,        "Liverpool",
+  "Leia Organa",    3.15,           2002,        "New York",
+  "Owen Lars",      3.60,           2003,        "Seattle",
+  "Beru Whitesun Lars", 4.05,       2004,        "Liverpool",
+  "R5-D4",          4.50,           2005,        "New York"
 )
 ```
 

--- a/troubleshooting-2.Rmd
+++ b/troubleshooting-2.Rmd
@@ -183,15 +183,15 @@ Manually create a tibble with 4 columns:
 
 ```{r}
 fakeStarWars <- tribble(
-  ~name,            ~birth_weight,  ~birth_year, ~birth_location,
-  "Luke Skywalker", 1.35,           1998,        "Liverpool",
-  "C-3PO",          1.80,           1999,        "Liverpool",
-  "R2-D2",          2.25,           2000,        "Seattle",
-  "Darth Vader",    2.70,           2001,        "Liverpool",
-  "Leia Organa",    3.15,           2002,        "New York",
-  "Owen Lars",      3.60,           2003,        "Seattle",
-  "Beru Whitesun Lars", 4.05,       2004,        "Liverpool",
-  "R5-D4",          4.50,           2005,        "New York"
+  ~name, ~birth_weight, ~birth_year, ~birth_location,
+  "Luke Skywalker", 1.35, 1998, "Liverpool, England",
+  "C-3PO", 1.80, 1999, "Liverpool, England",
+  "R2-D2", 2.25, 2000, "Seattle, WA",
+  "Darth Vader", 2.70, 2001, "Liverpool, England",
+  "Leia Organa", 3.15, 2002, "New York, NY",
+  "Owen Lars", 3.60, 2003, "Seattle, WA",
+  "Beru Whitesun Iars", 4.05, 2004, "Liverpool, England",
+  "R5-D4", 4.50, 2005, "New York, NY"
 )
 ```
 


### PR DESCRIPTION
Hi @audreyksiu 

I’ve fixed Exercise 6 in troubleshooting-2.Rmd by manually creating the fakeStarWars tibble with exactly 4 columns: name, birth_weight, birth_year, and birth_location. I also corrected the syntax errors (removed extra/trailing commas).

Please kindly review this PR and approve with a comment if all is good.